### PR TITLE
Fix-expression-typechecker

### DIFF
--- a/sablecc/grammar/postfix/semantics/Exceptions/invalidFunctionCallException.java
+++ b/sablecc/grammar/postfix/semantics/Exceptions/invalidFunctionCallException.java
@@ -1,13 +1,22 @@
 
 package postfix.semantics.Exceptions;
 
+import postfix.node.Node;
+
 /**
  * invalidFunctionCallException
  */
 public class invalidFunctionCallException extends RuntimeException {
 
+    private Node node;
+
     public invalidFunctionCallException(String message) {
         super();
     }
-    
+
+    public invalidFunctionCallException(String message, Node node) {
+        this(message);
+        this.node = node;
+    }
+
 }

--- a/sablecc/grammar/postfix/semantics/IdAttributes.java
+++ b/sablecc/grammar/postfix/semantics/IdAttributes.java
@@ -44,9 +44,11 @@ public class IdAttributes implements Cloneable {
         IdAttributes clone = new IdAttributes((TId) id.clone(), (TType) type.clone(), value, attributes);
         clone.setReturnType(getReturnType());
         // parameterNames og parameterTypes skulle meget gerne altid have samme størrelse, ellers er det grælt
-        for (int i = 0; i < parameterNames.size(); i++) {
-            clone.addParameter(parameterNames.get(i), parameterTypes.get(i));
-        }
+        clone.parameterNames = new ArrayList<>(parameterNames);
+        clone.parameterTypes = new ArrayList<>(parameterTypes);
+        // for (int i = 0; i < parameterNames.size(); i++) {
+        //     clone.addParameter(parameterNames.get(i), parameterTypes.get(i));
+        // }
         return clone;
     }
 

--- a/sablecc/grammar/postfix/semantics/IdAttributes.java
+++ b/sablecc/grammar/postfix/semantics/IdAttributes.java
@@ -5,12 +5,13 @@ import java.util.List;
 
 import postfix.node.TId;
 import postfix.node.TType;
+import postfix.semantics.Exceptions.invalidFunctionCallException;
 
 /**
  * Represents all necessary attributes, about an identifier, that a symbol table
  * monitors
  */
-public class IdAttributes {
+public class IdAttributes implements Cloneable {
 
     private TId id;
     private TType type;
@@ -36,6 +37,13 @@ public class IdAttributes {
         /** A special csv type */
         csv,
 
+    }
+    @Override
+    protected Object clone() throws CloneNotSupportedException {
+        IdAttributes clone = new IdAttributes(id,type,value,attributes);
+        clone.setReturnType(getReturnType());
+        //TODO giv fuld klon
+        return super.clone();
     }
 
     @Deprecated

--- a/sablecc/grammar/postfix/semantics/IdAttributes.java
+++ b/sablecc/grammar/postfix/semantics/IdAttributes.java
@@ -40,9 +40,10 @@ public class IdAttributes implements Cloneable {
     }
 
     @Override
-    protected Object clone() throws CloneNotSupportedException {
+    protected Object clone() {
         IdAttributes clone = new IdAttributes((TId) id.clone(), (TType) type.clone(), value, attributes);
         clone.setReturnType(getReturnType());
+        // parameterNames og parameterTypes skulle meget gerne altid have samme størrelse, ellers er det grælt
         for (int i = 0; i < parameterNames.size(); i++) {
             clone.addParameter(parameterNames.get(i), parameterTypes.get(i));
         }

--- a/sablecc/grammar/postfix/semantics/IdAttributes.java
+++ b/sablecc/grammar/postfix/semantics/IdAttributes.java
@@ -38,12 +38,47 @@ public class IdAttributes implements Cloneable {
         csv,
 
     }
+
     @Override
     protected Object clone() throws CloneNotSupportedException {
-        IdAttributes clone = new IdAttributes(id,type,value,attributes);
+        IdAttributes clone = new IdAttributes((TId) id.clone(), (TType) type.clone(), value, attributes);
         clone.setReturnType(getReturnType());
-        //TODO giv fuld klon
-        return super.clone();
+        for (int i = 0; i < parameterNames.size(); i++) {
+            clone.addParameter(parameterNames.get(i), parameterTypes.get(i));
+        }
+        return clone;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        IdAttributes other = (IdAttributes) obj;
+        boolean idEquals = id.getText().equals(other.id.getText());
+        boolean typeEquals = type.getText().equals(other.type.getText());
+        boolean parameterNamesEquals = parameterNames.equals(other.parameterNames);
+        boolean parameterTypesEquals = parameterTypes.equals(other.parameterTypes);
+        boolean returnTypeEquals = returnType.equals(other.returnType);
+        boolean attributesEquals = attributes.equals(other.attributes);
+
+        boolean res = idEquals &&
+                typeEquals &&
+                parameterNamesEquals &&
+                parameterTypesEquals &&
+                returnTypeEquals &&
+                attributesEquals;
+        return res;
+    }
+
+    @Override
+    public int hashCode() {
+        int hashCode = 0;
+        hashCode += id.getText().hashCode() +
+                type.getText().hashCode() +
+                parameterNames.hashCode() +
+                parameterTypes.hashCode() +
+                returnType.hashCode() +
+                attributes.hashCode();
+
+        return hashCode;
     }
 
     @Deprecated
@@ -107,8 +142,10 @@ public class IdAttributes implements Cloneable {
     public void setReturnType(String type) {
         returnType = type;
     }
+
     /**
      * Returns the list of parameter types in the order that they are declared
+     * 
      * @return
      */
     public QueueList<String> getParameterTypeListAsQueueList() {

--- a/sablecc/grammar/postfix/semantics/QueueList.java
+++ b/sablecc/grammar/postfix/semantics/QueueList.java
@@ -22,7 +22,7 @@ public class QueueList<E> implements Queue<E>{
      * @param list The list of elements to fill the queue with
      */
     public QueueList(List<E> list) {
-        internalList = list;
+        internalList = new ArrayList<>(list);
     }
 
     @Override

--- a/sablecc/grammar/postfix/semantics/SymbolTable.java
+++ b/sablecc/grammar/postfix/semantics/SymbolTable.java
@@ -183,7 +183,7 @@ public class SymbolTable implements Map<String, IdAttributes> {
             if (outerScope() == null) {
                 throw new IllegalArgumentException("Key " + key.toString() + " does not exist in symbol table");
             }
-            return (IdAttributes)outerScope().get(key).clone();
+            return (IdAttributes) outerScope().get(key).clone();
         }
 
         // If there is an outer scope, recursively search for the key in the outer scope
@@ -202,7 +202,11 @@ public class SymbolTable implements Map<String, IdAttributes> {
         // CreateNewScope(key, Scopekind.functionBlock, value.getReturnType());
         // }
         // Add the key-value pair to the current scope (hashMap)
-        return (IdAttributes)hashMap.put(key.stripTrailing(), value).clone();
+        IdAttributes res = hashMap.put(key.stripTrailing(), value);
+        if (res != null) {
+            res = (IdAttributes) res.clone();
+        }
+        return res;
     }
 
     @Override
@@ -232,7 +236,10 @@ public class SymbolTable implements Map<String, IdAttributes> {
         }
 
         // Return the removed IdAttributes (if any), otherwise null
-        return (IdAttributes)res.clone();
+        if (res != null) {
+            res = (IdAttributes) res.clone();
+        }
+        return res;
     }
 
     @Override
@@ -303,8 +310,12 @@ public class SymbolTable implements Map<String, IdAttributes> {
         for (int i = 0; i < parameterTypes.size(); i++) {
             attributes.addParameter(parameterTypes.get(i), parameterNames.get(i));
         }
+        IdAttributes res = hashMap.put(functionName, attributes);
+        if (res != null) {
+            res = (IdAttributes) res.clone();
+        }
 
-        return (IdAttributes)hashMap.put(functionName, attributes).clone();
+        return res;
     }
 
     /**
@@ -328,8 +339,11 @@ public class SymbolTable implements Map<String, IdAttributes> {
             throw new IllegalArgumentException("Function " + functionName + " is not a function");
         }
         attributes.setReturnType(returnType);
-
-        return (IdAttributes)hashMap.put(functionName, attributes).clone();
+        IdAttributes res = hashMap.put(functionName, attributes);
+        if (res != null) {
+            res = (IdAttributes) res.clone();
+        }
+        return res;
     }
 
     public SymbolTable CreateNewScope(String id, Scopekind kind, String type) {

--- a/sablecc/grammar/postfix/semantics/SymbolTable.java
+++ b/sablecc/grammar/postfix/semantics/SymbolTable.java
@@ -183,7 +183,7 @@ public class SymbolTable implements Map<String, IdAttributes> {
             if (outerScope() == null) {
                 throw new IllegalArgumentException("Key " + key.toString() + " does not exist in symbol table");
             }
-            return outerScope().get(key);
+            return (IdAttributes)outerScope().get(key).clone();
         }
 
         // If there is an outer scope, recursively search for the key in the outer scope
@@ -202,7 +202,7 @@ public class SymbolTable implements Map<String, IdAttributes> {
         // CreateNewScope(key, Scopekind.functionBlock, value.getReturnType());
         // }
         // Add the key-value pair to the current scope (hashMap)
-        return hashMap.put(key.stripTrailing(), value);
+        return (IdAttributes)hashMap.put(key.stripTrailing(), value).clone();
     }
 
     @Override
@@ -232,7 +232,7 @@ public class SymbolTable implements Map<String, IdAttributes> {
         }
 
         // Return the removed IdAttributes (if any), otherwise null
-        return res;
+        return (IdAttributes)res.clone();
     }
 
     @Override
@@ -304,7 +304,7 @@ public class SymbolTable implements Map<String, IdAttributes> {
             attributes.addParameter(parameterTypes.get(i), parameterNames.get(i));
         }
 
-        return hashMap.put(functionName, attributes);
+        return (IdAttributes)hashMap.put(functionName, attributes).clone();
     }
 
     /**
@@ -329,7 +329,7 @@ public class SymbolTable implements Map<String, IdAttributes> {
         }
         attributes.setReturnType(returnType);
 
-        return hashMap.put(functionName, attributes);
+        return (IdAttributes)hashMap.put(functionName, attributes).clone();
     }
 
     public SymbolTable CreateNewScope(String id, Scopekind kind, String type) {

--- a/sablecc/grammar/postfix/semantics/SymbolTable.java
+++ b/sablecc/grammar/postfix/semantics/SymbolTable.java
@@ -178,7 +178,7 @@ public class SymbolTable implements Map<String, IdAttributes> {
         // Check if the key exists in the current scope (hashMap) and return its value
         IdAttributes value = hashMap.get(key);
         if (value != null) {
-            return value;
+            return (IdAttributes) value.clone();
         } else {
             if (outerScope() == null) {
                 throw new IllegalArgumentException("Key " + key.toString() + " does not exist in symbol table");
@@ -191,6 +191,28 @@ public class SymbolTable implements Map<String, IdAttributes> {
         // return outerSymbolTable.get(key);
         // }
 
+    }
+
+    /**
+     * works like the public get, except it does not return a clone
+     * 
+     * @see {@link postfix.semantics.SymbolTable#get(Object)}
+     */
+    private IdAttributes privateGet(Object key) {
+        if (key == null) {
+            throw new NullPointerException("Key cannot be null");
+        }
+
+        // Check if the key exists in the current scope (hashMap) and return its value
+        IdAttributes value = hashMap.get(key);
+        if (value != null) {
+            return value;
+        } else {
+            if (outerScope() == null) {
+                throw new IllegalArgumentException("Key " + key.toString() + " does not exist in symbol table");
+            }
+            return outerScope().privateGet(key);
+        }
     }
 
     @Override
@@ -316,6 +338,25 @@ public class SymbolTable implements Map<String, IdAttributes> {
         }
 
         return res;
+    }
+
+    /**
+     * Adds parameter information to a function declaration inside the symbolTable
+     * 
+     * @param functionName  the declared name of the function
+     * @param parameterType the type of the parameter
+     * @param parameterName the name of the parameter
+     */
+    public void addFunctionParameter(String functionName, String parameterType, String parameterName) {
+        IdAttributes attributes = privateGet(functionName);
+        if (attributes == null) {
+            throw new NullPointerException("Function " + functionName + " does not exist");
+        }
+        if (attributes.getAttributes() != Attributes.function) {
+            throw new IllegalArgumentException(
+                    "Cannot add a parameter to " + functionName + " Because it is not a function");
+        }
+        attributes.addParameter(parameterType, parameterName);
     }
 
     /**

--- a/sablecc/grammar/postfix/semantics/visitors/SemanticVisitor.java
+++ b/sablecc/grammar/postfix/semantics/visitors/SemanticVisitor.java
@@ -150,7 +150,7 @@ public class SemanticVisitor extends DepthFirstAdapter {
         // TODO antal af givne parametre skal stemme overens med den erklærede funktion
         if (functionParameterTypeList.isEmpty()) {
             throw new invalidFunctionCallException(
-                    "Cannot pass parameters to a function that does not take any parameters");
+                    "Cannot pass parameters to a function that does not take any parameters",node);
         }
         node.getExpr().apply(new TypeVisitor(symbolTable, functionParameterTypeList.remove()));
 
@@ -168,7 +168,7 @@ public class SemanticVisitor extends DepthFirstAdapter {
             AFunctionCallFunctionCall functionCallNode = (AFunctionCallFunctionCall) parent;
             throw new invalidFunctionCallException("Cannot pass " + i + " parameters to a function that only takes "
                     + symbolTable.get(functionCallNode.getId().getText()).getParameterTypeListAsQueueList().size()
-                    + " parameters");
+                    + " parameters",node);
         }
         node.getExpr().apply(new TypeVisitor(symbolTable, functionParameterTypeList.remove()));
     }

--- a/sablecc/grammar/postfix/semantics/visitors/TopDclVisitor.java
+++ b/sablecc/grammar/postfix/semantics/visitors/TopDclVisitor.java
@@ -9,6 +9,7 @@ import postfix.semantics.SymbolTable.Scopekind;
 /**
  * Class for managing declarations, also responsible for calling TypeVisitor for
  * the right hand side (or statements in case of functions)
+ * 
  * @see {@link postfix.semantics.visitors.TypeVisitor}
  */
 public class TopDclVisitor extends SemanticVisitor {
@@ -66,11 +67,13 @@ public class TopDclVisitor extends SemanticVisitor {
                 Node functionDCL = node.parent();
 
                 while (!(functionDCL instanceof AFunctionDeclarationDcl)) {
-                    //find the parent function declaration
+                    // find the parent function declaration
                     functionDCL = functionDCL.parent();
                 }
                 AFunctionDeclarationDcl funcDCL = (AFunctionDeclarationDcl) functionDCL;
-                symbolTable.get(funcDCL.getId().getText()).addParameter(node.getType().getText(),
+                // symbolTable.get(funcDCL.getId().getText()).addParameter(node.getType().getText(),
+                // node.getId().getText());
+                symbolTable.addFunctionParameter(funcDCL.getId().getText(), node.getType().getText(),
                         node.getId().getText());
 
             }

--- a/sablecc/grammar/postfix/semantics/visitors/TypeVisitor.java
+++ b/sablecc/grammar/postfix/semantics/visitors/TypeVisitor.java
@@ -3,7 +3,6 @@ package postfix.semantics.visitors;
 import postfix.semantics.*;
 import postfix.semantics.Exceptions.*;
 
-import javax.print.FlavorException;
 
 import postfix.node.*;
 


### PR DESCRIPTION
symboltabel giver nu kopier af sine elementer så det kun er den der kan ændre på idattributes