### PR TITLE
Fix-function-nested-scopes

### DIFF
--- a/sablecc/grammar/postfix/Compiler.java
+++ b/sablecc/grammar/postfix/Compiler.java
@@ -38,5 +38,6 @@ public class Compiler {
 
     private void handleException(Exception e, String message) {
         System.out.println(e.getMessage() + " " + message);
+        e.printStackTrace();
     }
 }

--- a/sablecc/grammar/postfix/semantics/Exceptions/invalidReturnExpression.java
+++ b/sablecc/grammar/postfix/semantics/Exceptions/invalidReturnExpression.java
@@ -1,9 +1,16 @@
 package postfix.semantics.Exceptions;
 
+import postfix.node.AReturnStmt;
+
 public class invalidReturnExpression extends InvalidExpressionException {
+    private AReturnStmt returnStmt;
 
     public invalidReturnExpression(String message) {
         super(message);
+    }
+    public invalidReturnExpression(String message, AReturnStmt node) {
+        this(message);
+        returnStmt = node;
     }
 
 }

--- a/sablecc/grammar/postfix/semantics/SymbolTable.java
+++ b/sablecc/grammar/postfix/semantics/SymbolTable.java
@@ -95,7 +95,12 @@ public class SymbolTable implements Map<String, IdAttributes> {
         }
     }
 
-    public String getReturnType() {
+    /**
+     * Gets the return type of the current block. If current block is not a function, it searches outer scope
+     * @return The return type of the current function block
+     * @throws IllegalArgumentException if this and every outer scope is not a function
+     */
+    public String getReturnType() throws IllegalArgumentException {
         String returnType = null;
         if (kind != Scopekind.functionBlock) {
             SymbolTable outerTable = getOuterSymbolTable();
@@ -107,7 +112,7 @@ public class SymbolTable implements Map<String, IdAttributes> {
                 outerTable = getOuterSymbolTable();
             }
             if (returnType == null) {
-                // TODO kast en god exception
+                throw new IllegalArgumentException("Not inside a function block, scope does not return any value");
             }
         } else {
             returnType = this.returnType;

--- a/sablecc/grammar/postfix/semantics/TypeSystem.java
+++ b/sablecc/grammar/postfix/semantics/TypeSystem.java
@@ -11,40 +11,6 @@ import postfix.semantics.Exceptions.InvalidExpressionException;
  */
 public class TypeSystem {
 
-    private Set<String> operators = Set.of("+", "-", "*", "/", "%", "<", "<=", ">", ">=", "==", "!=", "and", "or");
-
-    public boolean isBinaryInfixOperator(String Operator) {
-        return operators.contains(Operator);
-    }
-
-    public boolean isUnaryOperator(String operator) {
-        return "!".equals(operator);
-    }
-
-    // public boolean isArithmeticType(String type) {
-    // return type.equals("int") || type.equals("float");
-    // }
-
-    // public boolean isArithmeticOperator(String operator) {
-    // return operator.equals("+") || operator.equals("-") || operator.equals("*")
-    // || operator.equals("/")
-    // || operator.equals("%");
-    // }
-
-    public String lookupUnaryType(String operandType, String operator)
-            throws InvalidExpressionException, IllegalArgumentException {
-        // skal måske bruges til typecasting (hvis vi når det)
-        if (!isUnaryOperator(operator)) {
-            throw new IllegalArgumentException("Operator " + operator + " not recognized");
-        }
-
-        if (!"bool".equals(operandType)) {
-            throw new InvalidExpressionException("Cannot perform " + operator + " on " + operandType);
-        }
-
-        return "bool";
-    }
-
     private static final Map<String, Map<String, String>> legalOperations;
 
     static {
@@ -61,6 +27,40 @@ public class TypeSystem {
         legalOperations.put("!=", Map.of("int", "int", "float", "float", "string", "string", "bool", "bool"));
         legalOperations.put("and", Map.of("bool", "bool"));
         legalOperations.put("or", Map.of("bool", "bool"));
+    }
+
+    private Set<String> operators = Set.of("+", "-", "*", "/", "%", "<", "<=", ">", ">=", "==", "!=", "and", "or");
+
+    // public boolean isArithmeticType(String type) {
+    // return type.equals("int") || type.equals("float");
+    // }
+
+    // public boolean isArithmeticOperator(String operator) {
+    // return operator.equals("+") || operator.equals("-") || operator.equals("*")
+    // || operator.equals("/")
+    // || operator.equals("%");
+    // }
+
+    public boolean isBinaryInfixOperator(String Operator) {
+        return operators.contains(Operator);
+    }
+
+    public boolean isUnaryOperator(String operator) {
+        return "!".equals(operator);
+    }
+
+    public String lookupUnaryType(String operandType, String operator)
+            throws InvalidExpressionException, IllegalArgumentException {
+        // skal måske bruges til typecasting (hvis vi når det)
+        if (!isUnaryOperator(operator)) {
+            throw new IllegalArgumentException("Operator " + operator + " not recognized");
+        }
+
+        if (!"bool".equals(operandType)) {
+            throw new InvalidExpressionException("Cannot perform " + operator + " on " + operandType);
+        }
+
+        return "bool";
     }
 
     //FIXME virker ikke

--- a/sablecc/grammar/postfix/semantics/TypeSystem.java
+++ b/sablecc/grammar/postfix/semantics/TypeSystem.java
@@ -22,16 +22,18 @@ public class TypeSystem {
     }
 
     // public boolean isArithmeticType(String type) {
-    //     return type.equals("int") || type.equals("float");
+    // return type.equals("int") || type.equals("float");
     // }
 
     // public boolean isArithmeticOperator(String operator) {
-    //     return operator.equals("+") || operator.equals("-") || operator.equals("*") || operator.equals("/")
-    //             || operator.equals("%");
+    // return operator.equals("+") || operator.equals("-") || operator.equals("*")
+    // || operator.equals("/")
+    // || operator.equals("%");
     // }
 
     public String lookupUnaryType(String operandType, String operator)
             throws InvalidExpressionException, IllegalArgumentException {
+        // skal måske bruges til typecasting (hvis vi når det)
         if (!isUnaryOperator(operator)) {
             throw new IllegalArgumentException("Operator " + operator + " not recognized");
         }
@@ -61,6 +63,7 @@ public class TypeSystem {
         legalOperations.put("or", Map.of("bool", "bool"));
     }
 
+    //FIXME virker ikke
     public String lookupResultingTypeNew(String LType, String RType, String operator)
             throws InvalidExpressionException, IllegalArgumentException {
         Map<String, String> typeMapping = legalOperations.get(operator);

--- a/sablecc/grammar/postfix/semantics/visitors/SemanticVisitor.java
+++ b/sablecc/grammar/postfix/semantics/visitors/SemanticVisitor.java
@@ -6,6 +6,7 @@ import postfix.semantics.IdAttributes;
 import postfix.semantics.QueueList;
 import postfix.semantics.SymbolTable;
 import postfix.semantics.Exceptions.invalidFunctionCallException;
+import postfix.semantics.IdAttributes.Attributes;
 
 /**
  * Responsible for verifying that a program is semantically correct
@@ -132,6 +133,13 @@ public class SemanticVisitor extends DepthFirstAdapter {
             throw new RuntimeException("Type mismatch: Cannot assign a value of type " + expressionType
                     + " to variable " + variableId + " of type " + variableType + ".");
         }
+        IdAttributes oldId = symbolTable.get(variableId);
+
+        if (!oldId.getAttributes().equals(Attributes.variable)) {
+            throw new invalidFunctionCallException("Cannot assign a new value to " + variableId + " because it is not a variable (it is " + oldId.getAttributes().name() + ")" , node);
+        }
+        symbolTable.put(node.getId().getText(),
+                new IdAttributes(node.getId(), oldId.getType(), expression.toString().strip(), oldId.getAttributes()));
     }
 
     // @Override
@@ -168,7 +176,7 @@ public class SemanticVisitor extends DepthFirstAdapter {
         if (node.getId() != null) {
             node.getId().apply(this);
         }
-        //! uh oh
+        // ! uh oh
         symbolTable = symbolTable.getFunctionSymbolTable(node.getId().getText());
         if (node.getFunctionParam() != null) {
             node.getFunctionParam().apply(this);
@@ -178,6 +186,7 @@ public class SemanticVisitor extends DepthFirstAdapter {
         }
         outAFunctionDeclarationDcl(node);
     }
+
     @Override
     public void inAFunctionCallFunctionCall(AFunctionCallFunctionCall node) {
         // funktionsparametre
@@ -192,7 +201,7 @@ public class SemanticVisitor extends DepthFirstAdapter {
         // TODO antal af givne parametre skal stemme overens med den erklærede funktion
         if (functionParameterTypeList.isEmpty()) {
             throw new invalidFunctionCallException(
-                    "Cannot pass parameters to a function that does not take any parameters",node);
+                    "Cannot pass parameters to a function that does not take any parameters", node);
         }
         node.getExpr().apply(new TypeVisitor(symbolTable, functionParameterTypeList.remove()));
 
@@ -210,7 +219,7 @@ public class SemanticVisitor extends DepthFirstAdapter {
             AFunctionCallFunctionCall functionCallNode = (AFunctionCallFunctionCall) parent;
             throw new invalidFunctionCallException("Cannot pass " + i + " parameters to a function that only takes "
                     + symbolTable.get(functionCallNode.getId().getText()).getParameterTypeListAsQueueList().size()
-                    + " parameters",node);
+                    + " parameters", node);
         }
         node.getExpr().apply(new TypeVisitor(symbolTable, functionParameterTypeList.remove()));
     }

--- a/sablecc/grammar/postfix/semantics/visitors/TopDclVisitor.java
+++ b/sablecc/grammar/postfix/semantics/visitors/TopDclVisitor.java
@@ -39,13 +39,12 @@ public class TopDclVisitor extends SemanticVisitor {
         node.apply(typeVisitor);
 
         // TODO get expr value
-        String value = "";
         if (symbolTable.DeclaredLocally(node.getId().getText())) {
             throw new VariableAlreadyDeclaredException(
                     "Variable" + node.getId().toString() + "has already been declared");
         } else {
             symbolTable.put(node.getId().toString(),
-                    new IdAttributes(node.getId(), node.getType(), value, Attributes.variable));
+                    new IdAttributes(node.getId(), node.getType(), node.getExpr().toString().strip(), Attributes.variable));
         }
     }
 

--- a/sablecc/grammar/postfix/semantics/visitors/TypeVisitor.java
+++ b/sablecc/grammar/postfix/semantics/visitors/TypeVisitor.java
@@ -1,10 +1,34 @@
 package postfix.semantics.visitors;
 
-import postfix.semantics.*;
-import postfix.semantics.Exceptions.*;
-
-
-import postfix.node.*;
+import postfix.node.AAndInfixBinInfixOp;
+import postfix.node.ADivisionInfixBinInfixOp;
+import postfix.node.AEqualityInfixBinInfixOp;
+import postfix.node.AExprValPrimeExpr;
+import postfix.node.AFunctionCallFunctionCall;
+import postfix.node.AFunctionCallParamFunctionCallParam;
+import postfix.node.AFunctionCallParamPrimeFunctionCallParamPrime;
+import postfix.node.AGreaterThanEqualInfixBinInfixOp;
+import postfix.node.AGreaterThanInfixBinInfixOp;
+import postfix.node.ALessThanEqualInfixBinInfixOp;
+import postfix.node.ALessThanInfixBinInfixOp;
+import postfix.node.AMinusInfixBinInfixOp;
+import postfix.node.AModuloInfixBinInfixOp;
+import postfix.node.AMultiplicationInfixBinInfixOp;
+import postfix.node.ANotEqualInfixBinInfixOp;
+import postfix.node.AOrInfixBinInfixOp;
+import postfix.node.APlusInfixBinInfixOp;
+import postfix.node.AReturnStmt;
+import postfix.node.AValBoolVal;
+import postfix.node.AValFloatnumVal;
+import postfix.node.AValIdVal;
+import postfix.node.AValIntnumVal;
+import postfix.node.AValStringVal;
+import postfix.semantics.QueueList;
+import postfix.semantics.SymbolTable;
+import postfix.semantics.TypeSystem;
+import postfix.semantics.Exceptions.InvalidExpressionException;
+import postfix.semantics.Exceptions.invalidFunctionCallException;
+import postfix.semantics.Exceptions.invalidReturnExpression;
 
 /**
  * Represents a type checker whose responsibilty is to type check expressions
@@ -50,6 +74,8 @@ public class TypeVisitor extends SemanticVisitor {
     protected QueueList<String> simplifiedTypeQueue;
     /** The type that an expression or return statement must return */
     protected String expressionType;
+    /** The type that an expression actually produces */
+    protected String actualExpressionType;
 
     @Override
     public void inAReturnStmt(AReturnStmt node) {
@@ -59,6 +85,11 @@ public class TypeVisitor extends SemanticVisitor {
 
     @Override
     public void outAReturnStmt(AReturnStmt node) {
+        if (!(expressionType.equals(actualExpressionType))) {
+            throw new invalidReturnExpression("Cannot return a value of type " + actualExpressionType
+                    + " on a function that has a return type of " + expressionType + " (Line: "
+                    + node.getKwReturn().getLine() + ")");
+        }
         // TODO skal lige testes
         // String expr = typeCheckExpression();
         // if (!expr.equals(expressionType)) {
@@ -84,10 +115,10 @@ public class TypeVisitor extends SemanticVisitor {
 
     @Override
     public void outAExprValPrimeExpr(AExprValPrimeExpr node) {
-        String resultingType = typeCheckExpression(node);
-    
+        actualExpressionType = typeCheckExpression(node);
+
         // Validate the resulting type and throw an exception if it's invalid
-        if ("INVALID_TYPE".equals(resultingType)) {
+        if ("INVALID_TYPE".equals(actualExpressionType)) {
             throw new InvalidExpressionException("Invalid expression type detected", node);
         }
     }
@@ -196,7 +227,7 @@ public class TypeVisitor extends SemanticVisitor {
 
     // @Override
     // public void outAFunctionCallFunctionCall(AFunctionCallFunctionCall node) {
-    //     // symbolTable = symbolTable.getOuterSymbolTable();
+    // // symbolTable = symbolTable.getOuterSymbolTable();
     // }
 
     // --PBinInfixOp nodes--

--- a/sablecc/grammar/semanticTest.txt
+++ b/sablecc/grammar/semanticTest.txt
@@ -15,6 +15,6 @@ export ok to ok4;
 # bool x = 2 < 3;
 
 int function foo(int a, int d) {return a+d ; };
-bool function bar(int c, bool b) { if b {return foo(c,2) < 10;} else {return -1;}; };
+bool function bar(int c, bool b) { if b {return foo(c,2) < 10;} else {return -1 != c;}; };
 
 bar(a,true);

--- a/sablecc/grammar/semanticTest.txt
+++ b/sablecc/grammar/semanticTest.txt
@@ -8,7 +8,7 @@ export ok to ok4;
 # bool c = 5 < 6;
 # bool d = 5.5 < 6.5;
 # int e = 5 * 5;
-# float f = 5.5 * 2.5;
+float f = 5.5 * 2.5;
 
 # Illegal expressions (Can still be done...)
 # bool g = 5 + 6;

--- a/sablecc/grammar/semanticTest.txt
+++ b/sablecc/grammar/semanticTest.txt
@@ -3,18 +3,18 @@ import "data.csv" as ok;
 export ok to ok4;
 
 # Legal expressions
-int a = 2+2+2;
-float b = 5.5 + 1.5;
-bool c = 5 < 6;
-bool d = 5.5 < 6.5;
-int e = 5 * 5;
-float f = 5.5 * 2.5;
+# int a = 2+2+2;
+# float b = 5.5 + 1.5;
+# bool c = 5 < 6;
+# bool d = 5.5 < 6.5;
+# int e = 5 * 5;
+# float f = 5.5 * 2.5;
 
 # Illegal expressions (Can still be done...)
 # bool g = 5 + 6;
 # bool x = 2 < 3;
 
-string function foo(int a, int d) {return a+d ; };
-bool function bar(int c, bool b) { if b {return foo(c,2);} else {return -1;}; };
+int function foo(int a, int d) {return a+d ; };
+bool function bar(int c, bool b) { if b {return foo(c,2) < 10;} else {return -1;}; };
 
 bar(a,true);


### PR DESCRIPTION
a functions return type is now remembered even if a function returns inside a nested block